### PR TITLE
Set default offset to zero for get_associations

### DIFF
--- a/src/monarch_py/implementations/solr/solr_implementation.py
+++ b/src/monarch_py/implementations/solr/solr_implementation.py
@@ -81,7 +81,7 @@ class SolrImplementation(
         object: str = None,
         entity: str = None,
         between: str = None,
-        offset: int = 1,
+        offset: int = 0,
         limit: int = 20,
     ) -> AssociationResults:
         """Retrieve paginated association records, with filter options


### PR DESCRIPTION
I noticed an odd result in monarch-api, turned out to be this typo