### PR TITLE
undo changes to model as gentypescript doesnt support metaobject yet

### DIFF
--- a/src/monarch_py/datamodels/model.yaml
+++ b/src/monarch_py/datamodels/model.yaml
@@ -78,8 +78,8 @@ classes:
     slot_usage:
       items:
         range: AssociationCount
-  MetaObject:
-    class_uri: linkml:Any
+  # MetaObject:
+  #   class_uri: linkml:Any
   Results:
     abstract: true
     slots:
@@ -132,7 +132,7 @@ slots:
     range: string
   items:
     description: A collection of items, with the type to be overriden by slot_usage
-    range: MetaObject
+    range: string
     inlined: true
     inlined_as_list: true
     multivalued: true
@@ -236,5 +236,6 @@ slots:
   xref:
     multivalued: true
     range: string
+
 
 

--- a/src/monarch_py/datamodels/model.yaml
+++ b/src/monarch_py/datamodels/model.yaml
@@ -100,7 +100,6 @@ classes:
     slot_usage:
         items:
           range: SearchResult
-  
   FacetValue:
     slots:
       - label
@@ -130,12 +129,6 @@ slots:
     range: integer
   description:
     range: string
-  items:
-    description: A collection of items, with the type to be overriden by slot_usage
-    range: string
-    inlined: true
-    inlined_as_list: true
-    multivalued: true
   facet_fields:
     inlined: true
     multivalued: true
@@ -160,6 +153,12 @@ slots:
     range: string
   in_taxon:
     range: string
+  items:
+    description: A collection of items, with the type to be overriden by slot_usage
+    range: string
+    inlined: true
+    inlined_as_list: true
+    multivalued: true
   knowledge_source:
     multivalued: true
   label:


### PR DESCRIPTION
I think we changed this for a reason, but. I'm gonna try setting item's range to string and let each class override it with slot_usage, see what happens