### PR TITLE
Add association count support

### DIFF
--- a/src/monarch_py/datamodels/model.py
+++ b/src/monarch_py/datamodels/model.py
@@ -20,6 +20,21 @@ class ConfiguredBaseModel(WeakRefShimBaseModel,
     pass                    
 
 
+class AssociationLabel(str, Enum):
+    
+    disease_phenotype = "disease_phenotype"
+    gene_phenotype = "gene_phenotype"
+    gene_interaction = "gene_interaction"
+    gene_pathway = "gene_pathway"
+    gene_expression = "gene_expression"
+    gene_orthology = "gene_orthology"
+    chemical_pathway = "chemical_pathway"
+    gene_function = "gene_function"
+    gene_associated_with_disease = "gene_associated_with_disease"
+    gene_affects_risk_for_disease = "gene_affects_risk_for_disease"
+    
+    
+
 class Association(ConfiguredBaseModel):
     
     aggregator_knowledge_source: Optional[List[str]] = Field(default_factory=list)

--- a/src/monarch_py/datamodels/model.yaml
+++ b/src/monarch_py/datamodels/model.yaml
@@ -2,10 +2,58 @@ id: https://w3id.org/monarch/monarch-py
 name: monarch-py
 prefixes:
   linkml: https://w3id.org/linkml/
+  biolink: https://w3id.org/biolink/
 description: Data datamodels for the Monarch Initiative data access library
 imports:
 - linkml:types
 default_range: string
+enums:
+  AssociationLabel:
+    description: >-
+      A grouping label for associations, which are not necessarily 1:1 with
+      biolink categories or predicates
+    permissible_values:
+      disease_phenotype:
+        description: >-
+          Any association between a disease and a phenotype
+        meaning: biolink:GeneToDiseaseAssociation
+      gene_phenotype:
+          description: >-
+              Any association between a gene and a phenotype
+          meaning: biolink:GeneToPhenotypicFeatureAssociation
+      gene_interaction:
+          description: >-
+              Any association between two genes
+          meaning: biolink:PairwiseGeneToGeneInteraction
+      gene_pathway:
+          description: >-
+              Any association between a gene and a pathway
+          meaning: biolink:GeneToPathwayAssociation
+      gene_expression:
+          description: >-
+              Expression association between a gene and an expression site
+          meaning: biolink:GeneToExpressionSiteAssociation
+      gene_orthology:
+          description: >-
+              Any association between two genes based on orthology
+          meaning: biolink:PairwiseGeneToGeneOrthologyAssociation
+      chemical_pathway:
+          description: >-
+              Any association between a chemical and a pathway
+          meaning: biolink:ChemicalToPathwayAssociation
+      gene_function:
+          description: >-
+              Any association between a gene and molecular activity
+          meaning: biolink:MacromolecularMachineToMolecularActivityAssociation
+      gene_associated_with_disease:
+        description: >-
+          Association between a gene and a disease that is not known to affect risk
+        meaning: biolink:gene_associated_with_disease
+      gene_affects_risk_for_disease:
+          description: >-
+              Association between a gene and a disease that is known to affect risk
+          meaning: biolink:affects_risk_for
+
 classes:
   Association:
     slots:

--- a/src/monarch_py/datamodels/solr.py
+++ b/src/monarch_py/datamodels/solr.py
@@ -34,6 +34,17 @@ class HistoPhenoKeys(Enum):
     growth = "HP:0001507"
     breast = "HP:0000769"
 
+class AssociationLabel(Enum):
+    disease_phenotype = "category:\"biolink:DiseaseToPhenotypicFeatureAssociation\""
+    gene_phenotype = "category:\"biolink:GeneToPhenotypicFeatureAssociation\""
+    gene_interaction = "category:\"biolink:PairwiseGeneToGeneInteraction\""
+    gene_pathway = "category:\"biolink:GeneToPathwayAssociation\""
+    gene_expression = "category:\"biolink:GeneToExpressionSiteAssociation\""
+    gene_orthology = "category:\"biolink:GeneToGeneHomologyAssociation\""
+    chemical_pathway = "category:\"biolink:ChemicalToPathwayAssociation\""
+    gene_function = "category:\"biolink:MacromolecularMachineToMolecularActivityAssociation\" OR category:\"biolink:MacromolecularMachineToBiologicalProcessAssociation\" OR category:\"biolink:GeneToCellularComponentAssociation\" OR category:\"biolink:MacromolecularMachineToCellularComponentAssociation\""
+    gene_associated_with_disease = "category:\"biolink:GeneToDiseaseAssociation\" AND predicate:\"biolink:gene_associated_with_condition\""
+    gene_affects_risk_for_disease = "category:\"biolink:GeneToDiseaseAssociation\" AND predicate:\"biolink:affects_risk_for\""
 
 class SolrQuery(BaseModel):
     q: str = "*:*"

--- a/src/monarch_py/interfaces/search_interface.py
+++ b/src/monarch_py/interfaces/search_interface.py
@@ -1,7 +1,7 @@
 from abc import ABC, abstractmethod
 from typing import List, Tuple
 
-from monarch_py.datamodels.model import SearchResults
+from monarch_py.datamodels.model import SearchResults, FacetValue
 
 
 class SearchInterface(ABC):
@@ -54,6 +54,7 @@ class SearchInterface(ABC):
         object_closure: str = None,
         entity: str = None,
         between: Tuple[str, str] = None,
+        association_label: AssociationLabel = None,
     ) -> SearchResults:
         """
         Get facet counts and facet query counts for associations
@@ -71,5 +72,15 @@ class SearchInterface(ABC):
         Returns:
             SearchResults: Dataclass representing results of a search, with zero rows returned but total count
             and faceting information populated
+        """
+        raise NotImplementedError
+
+    def get_association_counts(self, entity: str) -> List[FacetValue]:
+        """
+        Get counts of associations for a given entity
+        Args:
+            entity (str): Entity to get association counts for
+        Returns:
+            List[FacetValue]: List of FacetValue objects representing the counts of associations for the given entity
         """
         raise NotImplementedError

--- a/tests/integration/test_solr_search.py
+++ b/tests/integration/test_solr_search.py
@@ -1,5 +1,6 @@
 import pytest
 
+from monarch_py.datamodels.solr import AssociationLabel
 from monarch_py.implementations.solr.solr_implementation import SolrImplementation
 
 
@@ -63,3 +64,14 @@ def test_association_facet_query():
     assert response.facet_queries['object_closure:"HP:0000924"'].count > 20
     assert response.facet_queries['object_closure:"HP:0000707"'].count > 5
     assert response.facet_queries['object_closure:"HP:0000152"'].count > 20
+
+def test_association_counts():
+    si = SolrImplementation()
+    response = si.get_association_counts(entity="MONDO:0007947")
+    assert response
+    assert len(response) > 1
+
+def test_associations_by_label():
+    si = SolrImplementation()
+    response = si.get_associations(entity="HGNC:1100", association_label=AssociationLabel.gene_affects_risk_for_disease)
+


### PR DESCRIPTION
Adds support for generating association counts for an entity, and return association lists for an entity based on the labels returned from the association count endpoint
