### PR TITLE
Handle association tables when subject_closure or object_closure is empty

### DIFF
--- a/src/monarch_py/implementations/solr/solr_implementation.py
+++ b/src/monarch_py/implementations/solr/solr_implementation.py
@@ -501,9 +501,9 @@ class SolrImplementation(EntityInterface, AssociationInterface, SearchInterface)
     def _get_association_direction(
         self, entity: str, document: Dict
     ) -> AssociationDirectionEnum:
-        if document["subject"] == entity or entity in document["subject_closure"]:
+        if document.get("subject") == entity or entity in document.get("subject_closure"):
             direction = AssociationDirectionEnum.outgoing
-        elif document["object"] == entity or entity in document["object_closure"]:
+        elif document.get("object") == entity or entity in document.get("object_closure"):
             direction = AssociationDirectionEnum.incoming
         else:
             raise ValueError(f"Entity {entity} not found in association {document}")

--- a/src/monarch_py/implementations/solr/solr_implementation.py
+++ b/src/monarch_py/implementations/solr/solr_implementation.py
@@ -501,9 +501,11 @@ class SolrImplementation(EntityInterface, AssociationInterface, SearchInterface)
     def _get_association_direction(
         self, entity: str, document: Dict
     ) -> AssociationDirectionEnum:
-        if document.get("subject") == entity or entity in document.get("subject_closure"):
+        if document.get("subject") == entity \
+                or (document.get("subject_closure") and entity in document.get("subject_closure")):
             direction = AssociationDirectionEnum.outgoing
-        elif document.get("object") == entity or entity in document.get("object_closure"):
+        elif document.get("object") == entity \
+                or (document.get("object_closure") and entity in document.get("object_closure")):
             direction = AssociationDirectionEnum.incoming
         else:
             raise ValueError(f"Entity {entity} not found in association {document}")


### PR DESCRIPTION
- handle returned association documents that don't have subject_closure or object_closure
- handle `in NoneType` too
