### PR TITLE
Inlining schema fix for generating typescript

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -2743,4 +2743,4 @@ testing = ["big-O", "flake8 (<5)", "jaraco.functools", "jaraco.itertools", "more
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.8"
-content-hash = "21792eb9b56d4965b67bd6704aab09033999688009e896dfb6c07e48de31c438"
+content-hash = "a1098ebf096ad6b1de2c824eb08a941c515506a5a1de2d3d947c8615858776b8"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "monarch-py"
-version = "0.9.1"
+version = "0.9.2"
 description = "Monarch Initiative data access library"
 authors = [
     "Kevin Schaper <kevin@tislab.org>",

--- a/src/monarch_py/datamodels/model.yaml
+++ b/src/monarch_py/datamodels/model.yaml
@@ -205,16 +205,19 @@ slots:
     required: true
   facet_fields:
     description: Collection of facet field responses with the field values and counts
+    inlined: true
     inlined_as_list: true
     multivalued: true
     range: FacetField
   facet_queries:
     description: Collection of facet query responses with the query string values and counts
+    inlined: true
     inlined_as_list: true
     multivalued: true
     range: FacetValue
   facet_values:
     description: Collection of FacetValue label/value instances belonging to a FacetField
+    inlined: true
     inlined_as_list: true
     multivalued: true
     range: FacetValue

--- a/src/monarch_py/service/solr_service.py
+++ b/src/monarch_py/service/solr_service.py
@@ -6,7 +6,7 @@ from loguru import logger
 from pydantic import BaseModel
 
 from monarch_py.datamodels.solr import SolrQuery, SolrQueryResult, core
-from monarch_py.utils.utils import console, escape
+from monarch_py.utils.utils import escape
 
 
 class SolrService(BaseModel):


### PR DESCRIPTION
It looks like typescriptgen needs to have inlined=true along with inlined_as_list=true. We'll want to fix this on the linkml side, but to keep us moving I just added the extra schema config.
