### PR TITLE
Remove identifier:true for labels in schema

### DIFF
--- a/src/monarch_py/datamodels/model.yaml
+++ b/src/monarch_py/datamodels/model.yaml
@@ -105,9 +105,6 @@ classes:
     is_a: FacetValue
     slots:
       - id
-    slot_usage:
-      label:
-        identifier: false
   Results:
     abstract: true
     slots:
@@ -137,16 +134,10 @@ classes:
     slots:
       - label
       - count
-    slot_usage:
-        label:
-            identifier: true
   FacetField:
     slots:
       - label
       - facet_values
-    slot_usage:
-      label:
-        identifier: true
   AssociationTypeMapping:
     description: >-
       A data class to hold the necessary information to produce association type counts for given 


### PR DESCRIPTION
This is helpful for some slightly odd classes getting generated in typescript from the model
