### PR TITLE
Filter nodes without names from search

### DIFF
--- a/src/monarch_py/implementations/solr/solr_implementation.py
+++ b/src/monarch_py/implementations/solr/solr_implementation.py
@@ -240,6 +240,11 @@ class SolrImplementation(EntityInterface, AssociationInterface, SearchInterface)
         if filter_queries:
             query.filter_queries.extend(filter_queries)
 
+        # Search can't deal with entities that don't have names because we've made it a required field,
+        # we may or may not want them in the graph and in Solr, but we can safely leave them out of
+        # search
+        query.add_filter_query("name:*")
+
         query_result = solr.query(query)
         total = query_result.response.num_found
 


### PR DESCRIPTION
I made a PR in monarch ingest to filter out entities without names, but I'm not entirely sure that they should be removed from the graph. A partial solution is just that we can exclude them from search results. It would still be possible to run into pydantic errors when doing a get, or on an association, but I think it's less likely. When doing an open search only limiting by category, some of these entities went straight to the top.
