### PR TITLE
add --debug/--quiet flags to set log level

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "monarch-py"
-version = "0.9.4"
+version = "0.9.5"
 description = "Monarch Initiative data access library"
 authors = [
     "Kevin Schaper <kevin@tislab.org>",

--- a/src/monarch_py/solr_cli.py
+++ b/src/monarch_py/solr_cli.py
@@ -1,4 +1,5 @@
 from typing import List
+from typing_extensions import Annotated
 
 import pystow
 import typer
@@ -11,10 +12,22 @@ from monarch_py.utils.solr_cli_utils import (
     start_solr,
     stop_solr,
 )
-from monarch_py.utils.utils import console, format_output
+from monarch_py.utils.utils import console, format_output, set_log_level
 
 solr_app = typer.Typer()
 monarchstow = pystow.module("monarch")
+
+@solr_app.callback(invoke_without_command=True)
+def callback(
+    ctx: typer.Context,
+    quiet: Annotated[bool, typer.Option("--quiet", "-q", help="Set log level to warning")] = False,
+    debug: Annotated[bool, typer.Option("--debug", "-d", help="Set log level to debug")] = False,
+    ):
+    if ctx.invoked_subcommand is None:
+        typer.secho(f"\n\tNo command specified\n\tTry `monarch solr --help` for more information.\n", fg=typer.colors.YELLOW)
+        raise typer.Exit()
+    log_level = "DEBUG" if debug else "WARNING" if quiet else "INFO"
+    set_log_level(log_level)
 
 ############################
 ### SOLR DOCKER COMMANDS ###

--- a/src/monarch_py/sql_cli.py
+++ b/src/monarch_py/sql_cli.py
@@ -1,9 +1,25 @@
+from typing_extensions import Annotated
+
 import typer
 
 from monarch_py.implementations.sql.sql_implementation import SQLImplementation
-from monarch_py.utils.utils import console, format_output
+from monarch_py.utils.utils import console, format_output, set_log_level
 
 sql_app = typer.Typer()
+app_state = {"log_level": "WARNING"}
+
+
+@sql_app.callback(invoke_without_command=True)
+def callback(
+    ctx: typer.Context,
+    quiet: Annotated[bool, typer.Option("--quiet", "-q", help="Set log level to warning")] = False,
+    debug: Annotated[bool, typer.Option("--debug", "-d", help="Set log level to debug")] = False,
+    ):
+    if ctx.invoked_subcommand is None:
+        typer.secho(f"\n\tNo command specified\n\tTry `monarch sql --help` for more information.\n", fg=typer.colors.YELLOW)
+        raise typer.Exit()
+    log_level = "DEBUG" if debug else "WARNING" if quiet else "INFO"
+    set_log_level(log_level)
 
 
 @sql_app.command()

--- a/src/monarch_py/utils/utils.py
+++ b/src/monarch_py/utils/utils.py
@@ -47,10 +47,17 @@ def dict_factory(cursor, row):
     return {key: value for key, value in zip(fields, row)}
 
 
+def set_log_level(log_level: str):
+    """Sets the log level for the application."""
+    import loguru
+
+    loguru.logger.remove()
+    loguru.logger.add(sys.stderr, level=log_level)
+
+
 ### Output conversion methods ###
 
 FMT_INPUT_ERROR_MSG = "Text conversion method only accepts Entity, HistoPheno, AssociationCountList, or Results objects."
-
 
 def get_headers_from_obj(obj: ConfiguredBaseModel) -> list:
     """Return a list of headers from a pydantic model."""


### PR DESCRIPTION
resolves #62 

all commands now have `--debug # set log level to debug` and `--quiet # set log level to warning`, with info being the default. 

there aren't currently any log messages, but now we can add in debug messages with solr urls and other helpful info for development