### PR TITLE
Small bugfix for node page served from monarch-py

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "monarch-py"
-version = "0.12.0"
+version = "0.12.3"
 description = "Monarch Initiative data access library"
 authors = [
     "Kevin Schaper <kevin@tislab.org>",

--- a/src/monarch_py/implementations/solr/solr_implementation.py
+++ b/src/monarch_py/implementations/solr/solr_implementation.py
@@ -68,13 +68,13 @@ class SolrImplementation(EntityInterface, AssociationInterface, SearchInterface)
             mode_of_inheritance_associations = self.get_associations(
                 subject=id, predicate="biolink:has_mode_of_inheritance", offset=0
             )
-        if (
-            mode_of_inheritance_associations is not None
-            and len(mode_of_inheritance_associations.items) == 1
-        ):
-            node.inheritance = self._get_associated_entity(
-                mode_of_inheritance_associations.items[0], node
-            )
+            if (
+                mode_of_inheritance_associations is not None
+                and len(mode_of_inheritance_associations.items) == 1
+            ):
+                node.inheritance = self._get_associated_entity(
+                    mode_of_inheritance_associations.items[0], node
+                )
         node.node_hierarchy = self._get_node_hierarchy(node)
         node.association_counts = self.get_association_counts(id)
         return node
@@ -87,13 +87,13 @@ class SolrImplementation(EntityInterface, AssociationInterface, SearchInterface)
             entity = Entity(
                 id=association.object,
                 name=association.object_label,
-                category=association.object_category
+                category=association.object_category,
             )
         elif this_entity.id in association.object_closure:
             entity = Entity(
                 id=association.subject,
                 name=association.subject_label,
-                category=association.subject_category
+                category=association.subject_category,
             )
         else:
             raise ValueError(

--- a/tests/integration/test_solr_entity.py
+++ b/tests/integration/test_solr_entity.py
@@ -15,10 +15,19 @@ def test_entity():
     assert entity
     assert entity.name == "Marfan syndrome"
 
-def test_entity_with_extra():
+
+def test_disease_entity_with_extra():
     si = SolrImplementation()
     node: Node = si.get_entity("MONDO:0007947", extra=True)
     assert node
     assert node.association_counts
     assert node.node_hierarchy
     assert len(node.node_hierarchy.super_classes) > 0
+
+
+def test_gene_entity_with_extra():
+    si = SolrImplementation()
+    node: Node = si.get_entity("HGNC:5", extra=True)
+    assert node
+    assert node.association_counts
+    assert node.inheritance is None


### PR DESCRIPTION
- Remove a bracketzero from subject/object category, add a test for the node page response
- Fix indentation on mode_of_inheritance and add test to run the extras on a gene as well as a disease
